### PR TITLE
Documentation update

### DIFF
--- a/docs/RtD/conf.py
+++ b/docs/RtD/conf.py
@@ -270,7 +270,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
     # Override default css to get a larger width for local build                
     def setup(app):                                                              
         #app.add_javascript("custom.js")                                        
-        app.add_stylesheet('style.css')                                
+        app.add_css_file('style.css')
 else:                                                                            
     # Override default css to get a larger width for ReadTheDoc build            
     html_context = {                                                            

--- a/docs/RtD/developer/building/index.rst
+++ b/docs/RtD/developer/building/index.rst
@@ -7,6 +7,8 @@ Building Options
              reference documentation |br|
              (Probably a safer choice for information!)
 
+.. _installation-build-local:
+
 ApPredict-related Containers
 ----------------------------
 
@@ -15,37 +17,38 @@ This section refers to :
  #. `appredict-no-emulators <https://hub.docker.com/r/cardiacmodelling/appredict-no-emulators>`_  
  #. `appredict-with-emulators <https://hub.docker.com/r/cardiacmodelling/appredict-with-emulators>`_  
 
-.. _installation_build_local:
-
 .. warning:: It's important to note that even when using 32 processors it can
              30+ mins to build! |br|
              Equally, building appredict-with-emulators uses a lot of RAM as
              |ApPredict| loads files >1Gb into RAM. So better not to use all
              available processors for this step.
 
+.. note:: These instructions cover the case for building and testing |ApPredict| containers
+          locally, rather than for uploading to DockerHub.
+
 ::
 
    user@host:~> mkdir tmp && cd tmp
-   user@host:~/tmp> git clone --recursive https://github.com/CardiacModelling/ap-nimbus
-   user@host:~/tmp> cd ap-nimbus/appredict-docker/appredict-no-emulators
-   user@host:~/tmp/ap-nimbus/appredict-docker/appredict-no-emulators> 
+   user@host:~/tmp> git clone https://github.com/CardiacModelling/appredict-docker
+   user@host:~/tmp> cd appredict-docker/appredict-no-emulators
+   user@host:~/tmp/appredict-docker/appredict-no-emulators> 
 
-             Edit the Dockerfile to a new appredict_hash (and branch) value
+             Edit the Dockerfile to a new appredict tag value
 
-   user@host:~/tmp/ap-nimbus/appredict-docker/appredict-no-emulators> docker build --build-arg build_processors=<processors> -t appredict-no-emulators:<new version, e.g. mytest1> .
-   user@host:~/tmp/ap-nimbus/appredict-docker/appredict-no-emulators> docker run -it --rm appredict-no-emulators:<new version, e.g. mytest1>
+   user@host:~/tmp/appredict-docker/appredict-no-emulators> docker build --build-arg build_processors=<processors> -t appredict-no-emulators:<new version, e.g. mytest1> .
+   user@host:~/tmp/appredict-docker/appredict-no-emulators> docker run -it --rm appredict-no-emulators:<new version, e.g. mytest1>
 
-             Verify the ApPredict commit value against the commit hashes at https://github.com/Chaste/ApPredict/tags
+             Verify below the ApPredict commit value against the commit hashes at https://github.com/Chaste/ApPredict/tags
 
    bash-4.4$ apps/ApPredict/ApPredict 2> /dev/null | grep 'ApPredict is based on commit'
    bash-4.4$ exit
 
-   user@host:~/tmp/ap-nimbus/appredict-docker/appredict-no-emulators> cd ../appredict-with-emulators
-   user@host:~/tmp/ap-nimbus/appredict-docker/appredict-with-emulators>
+   user@host:~/tmp/appredict-docker/appredict-no-emulators> cd ../appredict-with-emulators
+   user@host:~/tmp/appredict-docker/appredict-with-emulators>
 
              Edit the Dockerfile `FROM` clause to appredict-no-emulators:<new version, e.g. mytest1>
 
-   user@host:~/tmp/ap-nimbus/appredict-docker/appredict-with-emulators> docker build --build-arg build_processors=<processors> -t appredict-with-emulators:<new version, e.g. mytest1> .
+   user@host:~/tmp/appredict-docker/appredict-with-emulators> docker build --build-arg build_processors=<processors> -t appredict-with-emulators:<new version, e.g. mytest1> .
 
 Why not use `Chaste/chaste-docker <https://github.com/Chaste/chaste-docker>`_?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/RtD/developer/building/index.rst
+++ b/docs/RtD/developer/building/index.rst
@@ -55,6 +55,30 @@ This section refers to :
 
    user@host:~/tmp/appredict-docker/appredict-with-emulators> docker build --build-arg build_processors=<processors> -t appredict-with-emulators:<new version, e.g. mytest1> .
 
+|ap-nimbus-client-direct| Container
+-----------------------------------
+
+This section refers to :
+
+ #. `ap-nimbus-client-direct <https://hub.docker.com/r/cardiacmodelling/ap-nimbus-client-direct>`_  
+
+Perhaps the most important thing to keep in mind when building a local container is to **temporarily**
+modify the :file:`docker/Dockerfile` to copy the content of the local dir (which you've probably
+just modified a bit for this change), e.g.
+
+::
+
+   user@host:~> mkdir tmp && cd tmp
+   user@host:~/tmp> git clone https://github.com/CardiacModelling/ap-nimbus-client
+   user@host:~/tmp> cd ap-nimbus-client
+   user@host:~/tmp/ap-nimbus-client> 
+
+             Edit the docker/Dockerfile to copy the local content
+             e.g. #RUN git clone --recursive --branch master --depth 1 https://github.com/CardiacModelling/ap-nimbus-client.git
+                  COPY / /opt/django/ap-nimbus-client
+
+   user@host:~/tmp/ap-nimbus-client> docker build -f docker/Dockerfile -t ap-nimbus-client-direct:<new version, e.g. mytest1> .
+
 Why not use `Chaste/chaste-docker <https://github.com/Chaste/chaste-docker>`_?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/RtD/developer/building/index.rst
+++ b/docs/RtD/developer/building/index.rst
@@ -23,6 +23,11 @@ This section refers to :
              |ApPredict| loads files >1Gb into RAM. So better not to use all
              available processors for this step.
 
+.. note:: Within the :file:`Dockerfile`\s we have not enforced version-controlling of images or
+          dependencies (e.g. by specifying the base image tag with hash, or by using specific
+          versions of software, e.g. libhdf5-dev version *X*), as the built container represents
+          a unique snapshot in time. See `No version-controlling in appredict-chaste-libs Dockerfile <https://github.com/CardiacModelling/appredict-docker/issues/4>`_.
+
 .. note:: These instructions cover the case for building and testing |ApPredict| containers
           locally, rather than for uploading to DockerHub.
 

--- a/docs/RtD/developer/container/index.rst
+++ b/docs/RtD/developer/container/index.rst
@@ -56,6 +56,42 @@ What this does on an ``iptables``-based system is adjust the firewall such as :
 
   :
 
+Django static file creation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Within `ap-nimbus-client/client/static <https://github.com/CardiacModelling/ap-nimbus-client/tree/master/client/static>`_ 
+there are the static files which the Django UI references, e.g. images, css, js.
+
+The following commands represent an example of how a new minified :file:`main-min.js` can be generated.
+
+**Note** : You need to have ``npm`` (so you probably need ``node.js`` installed - e.g. ``apt install nodejs npm``).
+
+.. warning:: 1. The commands below also modify the version-controlled file :file:`npm-shrinkwrap.json`, but don't
+             commit this change! |br|
+             2. They also fill up :file:`node_modules` with almost 100Mb of stuff which you **really**
+             don't want to be copied into a container! Better to delete the content of this
+             directory before building the container.
+
+::
+
+   user@host:~/git/ap-nimbus-client/client/static> npm install gulp
+   user@host:~/git/ap-nimbus-client/client/static> ./node_modules/gulp/bin/gulp.js      # <-- reads gulpfile.js
+   user@host:~/git/ap-nimbus-client/client/static> find ./ -mmin -1 -type f
+   ./css/style-min.css
+   ./build/js/main-min.js
+
+If you're just wanting to create and use an unminified version of :file:`main.js` for local testing, you can
+try the following.
+
+::
+
+   user@host:~/git/ap-nimbus-client/client/static> sed -i "s/noSource: true/noSource: true, ignoreFiles: ['main.js']/g" gulpfile.js
+   user@host:~/git/ap-nimbus-client/client/static> sed -i "s/main-min/main/g" ../templates/includes/head.html
+   user@host:~/git/ap-nimbus-client/client/static> ./node_modules/gulp/bin/gulp.js	# <-- reads gulpfile.js
+   user@host:~/git/ap-nimbus-client/client/static> find ./ -mmin -1 -type f
+   ./css/style-min.css
+   ./build/js/main.js
+
 Developing in container
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/RtD/developer/updating-appredict/index.rst
+++ b/docs/RtD/developer/updating-appredict/index.rst
@@ -3,10 +3,10 @@
 Updating |ApPredict|
 ====================
 
-This section explains what to do to get changed to |ApPredict| to trickle through to the (containerised)
-|AP-Portal|. The way the containerised portal works, is that |ApPredict| runs inside the |ap-nimbus-app-manager|
-container. Therefore we do not need to worry about the client or database components (unless |ApPredict| input
-or output formats have changed!).
+This section explains what to do to get changes to the |ApPredict| *main* branch to trickle through to the
+(containerised) |AP-Portal|. The way the containerised portal works, is that |ApPredict| runs inside the
+|ap-nimbus-app-manager| container. Therefore we do not need to worry about the client or database components
+(unless |ApPredict| input or output formats have changed!).
 
 Prerequisites
 -------------

--- a/docs/RtD/developer/updating-appredict/index.rst
+++ b/docs/RtD/developer/updating-appredict/index.rst
@@ -51,7 +51,10 @@ Steps
 .. warning:: :underline:`For brevity only` the cloning, updating and pushing to *master* branch 
              is illustrated - new branches and Pull Requests are recommended. |br| |br|
              It would be better to **not** run the "build" instructions on servers hosting |ap-nimbus| -
-             to avoid inadvertently overwriting existing containers, or possibly ingesting cached layers.
+             to avoid inadvertently overwriting existing containers. |br| |br|
+             If you are concerned about ingesting cached layers, then use the option ``--no-cache`` 
+             during docker building. (Alternative techniques are discussed in 
+             `Stack Overflow - How to force Docker for a clean build of an image <https://stackoverflow.com/questions/35594987/how-to-force-docker-for-a-clean-build-of-an-image>`_)
 
 - Make changes to the underlying |ApPredict| and assign an annotated tag to the |ApPredict|
   default branch, e.g.
@@ -89,9 +92,10 @@ Steps
   - |ap-nimbus-app-manager| tag value (*"<new_ap-nimbus-app-manager_tag>"*) |br|
     See https://hub.docker.com/r/cardiacmodelling/ap-nimbus-app-manager/tags
 
-- Build and upload to Docker Hub a new |appredict-no-emulators| and |appredict-with-emulators| (see also 
-  :ref:`installation-build-local` for building/testing locally if you don't want to be uploading
-  new versions to Docker Hub just yet).
+- Build and upload to Docker Hub a new |appredict-no-emulators| and |appredict-with-emulators| |br| |br|
+  **Note** : If you don't want to be uploading new versions to Docker Hub immediately as per the following
+  instructions, see :ref:`installation-build-local` and :ref:`running-appredict` for building/testing
+  locally.
 
   ::
 

--- a/docs/RtD/developer/updating-appredict/index.rst
+++ b/docs/RtD/developer/updating-appredict/index.rst
@@ -11,18 +11,25 @@ or output formats have changed!).
 Prerequisites
 -------------
 
- #. Write access to https://github.com/Chaste/ApPredict
+ #. Write access to https://github.com/Chaste/ApPredict |br|
+    If you have a GitHub `personal access token <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_,
+    you may need to run ``git clone https://<user>:<token>@github.com/repo/project`` or 
+    ``git remote set-url origin https://<user>:<token>@github.com/repo/project``
  #. Write access to https://github.com/CardiacModelling/ap-nimbus
  #. Write access to https://github.com/CardiacModelling/ap-nimbus-app-manager
  #. Write access to https://github.com/CardiacModelling/appredict-docker
- #. Write access to https://hub.docker.com/u/cardiacmodelling
+ #. Write access to https://hub.docker.com/u/cardiacmodelling |br|
+    You may need to run ``docker login -u <user> -p <pwd> docker.io`` at the command line to authenticate
  #. (Optional) https://readthedocs.org/ access (to rebuild https://ap-nimbus.readthedocs.io/)
+ #. A multicore server with good upload speeds as a build machine!
 
 Steps
 -----
 
-.. warning:: For brevity **only**, the cloning, updating and pushing to *master* branch is illustrated. |br|
-             New branches and Pull Requests are recommended.
+.. warning:: :underline:`For brevity only` the cloning, updating and pushing to *master* branch 
+             is illustrated - new branches and Pull Requests are recommended. |br| |br|
+             It would be better to **not** run the "build" instructions on servers hosting |ap-nimbus| -
+             to avoid inadvertently overwriting existing containers, or possibly ingesting cached layers.
 
 - Make changes to the underlying |ApPredict| and assign an annotated tag to the |ApPredict|
   default branch, e.g.
@@ -98,13 +105,15 @@ Steps
 
     - https://github.com/CardiacModelling/ap-nimbus/tree/master/docs/RtD
 
+      You may need to install (Ubuntu) ``sphinx``, ``sphinx_rtd_theme`` / (Fedora) ``python3-sphinx``, ``python3-sphinx_rtd_theme``.
+
       ::
 
         user@host:~/git> git clone https://github.com/CardiacModelling/ap-nimbus
         user@host:~/git> cd ap-nimbus/docs/RtD
         user@host:~/git/ap-nimbus/docs/RtD>
         # Edit .rst files (see https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)
-        user@host:~/git/ap-nimbus/docs/RtD> make clean html           # <-- After this, view content of _build/html/index.html in browser!
+        user@host:~/git/ap-nimbus/docs/RtD> make clean html           # <-- After this, view content of _build/html/index.html in browser to verify!
     
     - :file:`README.md` files anywhere (e.g. ``appredict-docker``, ``ap-nimbus``).
 
@@ -119,7 +128,7 @@ Steps
      user@host:~/git/ap-nimbus> git commit -m "Commit message!"
      user@host:~/git/ap-nimbus> git push
 
-- Update |ap-nimbus-app-manager|
+- (Optional) Update |ap-nimbus-app-manager|
 
   ::
 
@@ -128,7 +137,7 @@ Steps
      user@host:~/git/ap-nimbus-app-manager>
      # In Dockerfile
      #   1. Update "FROM cardiacmodelling/appredict-with-emulators:<new_ap-nimbus-app-manager_tag>"
-     user@host:~/git/ap-nimbus-app-manager> docker build -t cardiacmodelling/ap-nimbus-app-manager:<new_ap-nimbus-app-manager_tag> .   # <-- Note trailing "."
+     user@host:~/git/ap-nimbus-app-manager> docker build --build-arg build_processors=<processors> -t cardiacmodelling/ap-nimbus-app-manager:<new_ap-nimbus-app-manager_tag> .   # <-- Note trailing "."
      user@host:~/git/ap-nimbus-app-manager> docker push cardiacmodelling/ap-nimbus-app-manager:<new_ap-nimbus-app-manager_tag>
 
   - Test the newly-uploaded Docker Hub containers.
@@ -144,6 +153,7 @@ Steps
     - GitHub/RtD - Make any relevant changes to :
 
       - https://github.com/CardiacModelling/ap-nimbus/tree/master/docs/RtD |br|
+        (See info above for how to verify changes locally)
       - :file:`README.md` files anywhere.
 
   - Commit and push GitHub changes

--- a/docs/RtD/developer/updating-appredict/index.rst
+++ b/docs/RtD/developer/updating-appredict/index.rst
@@ -23,6 +23,28 @@ Prerequisites
  #. (Optional) https://readthedocs.org/ access (to rebuild https://ap-nimbus.readthedocs.io/)
  #. A multicore server with good upload speeds as a build machine!
 
+Updating Git submodules
+-----------------------
+
+Easiest is updating all the submodules at once: 
+
+::
+
+  git clone --recursive https://github.com/cardiacModelling/ap-nimbus  
+  cd ap-nimbus  
+  git submodule update --remote 
+  git add -A 
+  git commit –m "Updated submodules" 
+  git push 
+
+ 
+If you want to update just 1 submodule then add the path in the update line. E.g. 
+
+::
+
+  git submodule update -–remote client-direct 
+
+
 Steps
 -----
 

--- a/docs/RtD/developer/updating-appredict/index.rst
+++ b/docs/RtD/developer/updating-appredict/index.rst
@@ -104,7 +104,7 @@ Steps
         user@host:~/git> cd ap-nimbus/docs/RtD
         user@host:~/git/ap-nimbus/docs/RtD>
         # Edit .rst files (see https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)
-        user@host:~/git/ap-nimbus/docs/RtD> rm -rf _build/*; make html           # <-- View content of _build/html/index.html in browser!
+        user@host:~/git/ap-nimbus/docs/RtD> make clean html           # <-- After this, view content of _build/html/index.html in browser!
     
     - :file:`README.md` files anywhere (e.g. ``appredict-docker``, ``ap-nimbus``).
 

--- a/docs/RtD/developer/updating-appredict/index.rst
+++ b/docs/RtD/developer/updating-appredict/index.rst
@@ -1,36 +1,161 @@
 .. include:: ../../global.rst
 
-Updating ApPredict
-==================
+Updating |ApPredict|
+====================
 
-This section explains what to do to get changed to ApPredict to trickle through to the (containerised) ApPortal.
-The way the containerised portal works, is that ApPredict runs inside the app-manager container. Therefore we do not need to worry about the client or database components.
+This section explains what to do to get changed to |ApPredict| to trickle through to the (containerised)
+|AP-Portal|. The way the containerised portal works, is that |ApPredict| runs inside the |ap-nimbus-app-manager|
+container. Therefore we do not need to worry about the client or database components (unless |ApPredict| input
+or output formats have changed!).
 
-After a change to ApPredict has been made and pushed to the master branch the steps to use it with the portal are as follows:
+Prerequisites
+-------------
 
-- Assign a tag to the ApPredict version as follows `gittag -a <name_of_tag> -m 'some messages for git history'` followed by `git push --tags`
-- Checkout the appredict-docker repository (https://github.com/CardiacModelling/)
-- Update the tag used for ApPredict at the top of the `Dockerfile` in appredict-no-emulators (to the one assigned earlier).
-- Build the new appredict-no-emulators (see also `../building`) e.g. cd into `appredict-no-emulators` and then `docker build . -t cardiacmodelling/appredict-no-emulators:0.0.10` where 0.0.10 is the next available version. See docker hub (https://hub.docker.com/repository/docker/cardiacmodelling/appredict-no-emulators/general)
-- Upload the new container to docker hub e.g. `docker push cardiacmodelling/appredict-no-emulators:0.0.10`
-- Edit the readme on dockerhub (https://hub.docker.com/repository/docker/cardiacmodelling/appredict-no-emulators/general) with the new version number & change log
-- Go to `appredict-with-emulators` and update the `Dockerfile`, updating the version number of `appredict-no-emulators` referenced in the first line.
-- Build `appredict-with-emulators`, using the next available version as tag, and also push this to docker hub.
-- Edit the readme on dockerhub (https://hub.docker.com/repository/docker/cardiacmodelling/appredict-with-emulators/general) with the new version number & change log
-- Commit & push changed to git
-- checkout the app manager (https://github.com/CardiacModelling/ap-nimbus-app-manager/tree/master)
-- Update the docker file, updating the version of `appredict-with-emulators` referenced to the latest version.
-- Build `ap-nimbus-app-manager` again, using the next available version as a tag
-- Push to docker hub
-- Update the readme on docker hub (https://hub.docker.com/repository/docker/cardiacmodelling/ap-nimbus-app-manager/general)
-- List the current running docker images `ducker ps`. There should be an instance of app-manager
-- Remove the current running instance of app-manager: e.g. `docker rm -f ap-nimbus-ap-manager`
-- Then re-run the latest version of the app-manager, see https://ap-nimbus.readthedocs.io/en/latest/developer/container/index.html#ap-nimbus-app-manager
-- Do a simple test simulation on the portal just to check that it works.
-- Optionally you can remove the old image with the `rmi` command, use docker image list to see the current images that you have.
-- Check out the ap-nimbus repository (https://github.com/CardiacModelling/ap-nimbus)
-- Update the changed components:
+ #. Write access to https://github.com/Chaste/ApPredict
+ #. Write access to https://github.com/CardiacModelling/ap-nimbus
+ #. Write access to https://github.com/CardiacModelling/ap-nimbus-app-manager
+ #. Write access to https://github.com/CardiacModelling/appredict-docker
+ #. Write access to https://hub.docker.com/u/cardiacmodelling
+ #. (Optional) https://readthedocs.org/ access (to rebuild https://ap-nimbus.readthedocs.io/)
 
-   - `git submodule update appredict-docker --remote`
-   - `git submodule update app-manager --remote`
-- Git commit & push
+Steps
+-----
+
+.. warning:: For brevity **only**, the cloning, updating and pushing to *master* branch is illustrated. |br|
+             New branches and Pull Requests are recommended.
+
+- Make changes to the underlying |ApPredict| and assign an annotated tag to the |ApPredict|
+  default branch, e.g.
+
+  ::
+
+      user@host:~/git> git clone https://github.com/Chaste/ApPredict
+      user@host:~/git> cd ApPredict
+      user@host:~/git/ApPredict> git tag -a <new_appredict_tag> -m 'some messages for git history'
+      user@host:~/git/ApPredict> git push --tags
+
+- **Optional Step!** : :underline:`Only` if there's been a change in |ApPredict|\'s *chaste-libs* dependencies and
+  we need a new |appredict-chaste-libs|.
+  
+  - Determine the next available |appredict-chaste-libs| container tag value (*"<new_appredict-chaste-libs_tag>"*) |br|
+    See https://hub.docker.com/r/cardiacmodelling/appredict-chaste-libs
+  - Build and upload to Docker Hub a new |appredict-chaste-libs|.
+
+    ::
+
+       user@host:~/git> git clone https://github.com/CardiacModelling/appredict-docker
+       user@host:~/git> cd appredict-docker/appredict-chaste-libs
+       user@host:~/git/appredict-docker/appredict-chaste-libs>
+       # Edit Dockerfile (and if helpful, README.md)
+       user@host:~/git/appredict-docker/appredict-chaste-libs> docker build -t cardiacmodelling/appredict-chaste-libs:<new_appredict-chaste-libs_tag> .     # <-- Note trailing "."
+       user@host:~/git/appredict-docker/appredict-chaste-libs> docker push cardiacmodelling/appredict-chaste-libs:<new_appredict-chaste-libs_tag>
+       # The git committing, pushing, etc., will occur in a later step.
+
+- Determine the next available container tag values.
+
+  - |appredict-no-emulators| tag value (*"<new_appredict-no-emulators_tag>"*) |br|
+    See https://hub.docker.com/r/cardiacmodelling/appredict-no-emulators/tags
+  - |appredict-with-emulators| tag value (*"<new_appredict-with-emulators_tag>"*) |br|
+    See https://hub.docker.com/r/cardiacmodelling/appredict-with-emulators/tags
+  - |ap-nimbus-app-manager| tag value (*"<new_ap-nimbus-app-manager_tag>"*) |br|
+    See https://hub.docker.com/r/cardiacmodelling/ap-nimbus-app-manager/tags
+
+- Build and upload to Docker Hub a new |appredict-no-emulators| and |appredict-with-emulators| (see also 
+  :ref:`installation-build-local` for building/testing locally if you don't want to be uploading
+  new versions to Docker Hub just yet).
+
+  ::
+
+     user@host:~/git> cd appredict-docker/appredict-no-emulators
+     user@host:~/git/appredict-docker/appredict-no-emulators>
+     # In Dockerfile :
+     #   1. Optionally update "FROM cardiacmodelling/appredict-chaste-libs:<new_appredict-chaste-libs_tag>"
+     #      if you're using a new version of chaste libs
+     #   2. Optionally update "ARG chaste_tag=<Chaste ver>" if you're using a new version of Chaste
+     #   3. Update "ARG appredict_tag=<new_appredict_tag>"
+     user@host:~/git/appredict-docker/appredict-no-emulators> docker build --build-arg build_processors=<processors> -t cardiacmodelling/appredict-no-emulators:<new_appredict-no-emulators_tag> .   # <-- Note trailing "."
+     user@host:~/git/appredict-docker/appredict-no-emulators> docker push cardiacmodelling/appredict-no-emulators:<new_appredict-no-emulators_tag>
+     user@host:~/git/appredict-docker/appredict-no-emulators> cd ../appredict-with-emulators
+     # In Dockerfile :
+     #   1. Update "FROM cardiacmodelling/appredict-no-emulators:<new_appredict-no-emulators_tag>"
+     user@host:~/git/appredict-docker/appredict-with-emulators> docker build --build-arg build_processors=<processors> -t cardiacmodelling/appredict-with-emulators:<new_appredict-with-emulators_tag> .  # <-- Note trailing "."
+     user@host:~/git/appredict-docker/appredict-with-emulators> docker push cardiacmodelling/appredict-with-emulators:<new_appredict-with-emulators_tag>
+     # The git committing, pushing, etc., will occur in a later step.
+
+- Test the newly-uploaded Docker Hub containers.
+
+  See instructions at :ref:`running-appredict`
+
+- Update documentation
+
+  - Docker Hub, with version numbers and change logs, e.g.
+
+    - (Optional) https://hub.docker.com/repository/docker/cardiacmodelling/appredict-chaste-libs/general
+    - https://hub.docker.com/repository/docker/cardiacmodelling/appredict-no-emulators/general
+    - https://hub.docker.com/repository/docker/cardiacmodelling/appredict-with-emulators/general
+
+  - GitHub/RtD - Make any relevant changes to :
+
+    - https://github.com/CardiacModelling/ap-nimbus/tree/master/docs/RtD
+
+      ::
+
+        user@host:~/git> git clone https://github.com/CardiacModelling/ap-nimbus
+        user@host:~/git> cd ap-nimbus/docs/RtD
+        user@host:~/git/ap-nimbus/docs/RtD>
+        # Edit .rst files (see https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)
+        user@host:~/git/ap-nimbus/docs/RtD> rm -rf _build/*; make html           # <-- View content of _build/html/index.html in browser!
+    
+    - :file:`README.md` files anywhere (e.g. ``appredict-docker``, ``ap-nimbus``).
+
+- Commit and push GitHub changes
+
+  ::
+
+     user@host:~/git/appredict-docker> git commit -m "Commit message!"
+     user@host:~/git/appredict-docker> git push
+     user@host:~/git/appredict-docker> cd ../ap-nimbus
+     user@host:~/git/ap-nimbus> git submodule update appredict-docker --remote
+     user@host:~/git/ap-nimbus> git commit -m "Commit message!"
+     user@host:~/git/ap-nimbus> git push
+
+- Update |ap-nimbus-app-manager|
+
+  ::
+
+     user@host:~/git> git clone https://github.com/CardiacModelling/ap-nimbus-app-manager
+     user@host:~/git> cd ap-nimbus-app-manager
+     user@host:~/git/ap-nimbus-app-manager>
+     # In Dockerfile
+     #   1. Update "FROM cardiacmodelling/appredict-with-emulators:<new_ap-nimbus-app-manager_tag>"
+     user@host:~/git/ap-nimbus-app-manager> docker build -t cardiacmodelling/ap-nimbus-app-manager:<new_ap-nimbus-app-manager_tag> .   # <-- Note trailing "."
+     user@host:~/git/ap-nimbus-app-manager> docker push cardiacmodelling/ap-nimbus-app-manager:<new_ap-nimbus-app-manager_tag>
+
+  - Test the newly-uploaded Docker Hub containers.
+
+    See instructions at :ref:`running-app-manager`
+
+  - Update documentation
+
+    - Docker Hub, with version numbers and change logs, e.g.
+
+      - https://hub.docker.com/repository/docker/cardiacmodelling/ap-nimbus-app-manager/general
+
+    - GitHub/RtD - Make any relevant changes to :
+
+      - https://github.com/CardiacModelling/ap-nimbus/tree/master/docs/RtD |br|
+      - :file:`README.md` files anywhere.
+
+  - Commit and push GitHub changes
+
+    ::
+
+       user@host:~/git/ap-nimbus-app-manager> git commit -m "Commit message!"
+       user@host:~/git/ap-nimbus-app-manager> git push
+       user@host:~/git/ap-nimbus-app-manager> cd ../ap-nimbus
+       user@host:~/git/ap-nimbus> git submodule update ap-nimbus-app-manager --remote
+       user@host:~/git/ap-nimbus> git push
+
+- Updating the test/production servers
+
+  See internal documentation


### PR DESCRIPTION
Updating a few documents :

- As part of https://github.com/CardiacModelling/ap-nimbus/issues/65
  - Rewriting of "Updating ApPredict"
  - Added Django static file creation information
- Update the RtD build config setting (to allow for recent Sphinx install builds)
- Added `git submodule` updating instructions